### PR TITLE
Add 'bower install' to gulp build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var gulp = require('gulp');
 var karma = require('karma').server;
 var argv = require('yargs').argv;
 var $ = require('gulp-load-plugins')();
+var bower = require('gulp-bower');
 
 gulp.task('styles', function() {
   return gulp.src('app/styles/main.less')
@@ -151,7 +152,7 @@ gulp.task('builddist', ['jshint', 'html', 'images', 'fonts', 'extras'],
   return gulp.src('dist/**/*').pipe($.size({title: 'build', gzip: true}));
 });
 
-gulp.task('build', ['clean'], function() {
+gulp.task('build', ['clean', 'bower'], function() {
   gulp.start('builddist');
 });
 
@@ -168,6 +169,10 @@ gulp.task('serveprod', function() {
   });
 });
 
-gulp.task('heroku:',['build'], function(){
+gulp.task('heroku:', ['build'], function(){
   console.log('herokuduction');
+});
+
+gulp.task('bower', function() {
+  return bower();
 });

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "del": "^1.1.1",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^2.1.0",
+    "gulp-bower": "0.0.13",
     "gulp-cache": "^0.2.8",
     "gulp-csso": "^1.0.0",
     "gulp-filter": "^2.0.2",


### PR DESCRIPTION
gulp now performs a 'bower install' before building,
because 'bower_components' are removed from git now,
and heroku needs to get 'bower_components' first